### PR TITLE
Fix roots_quintic in polyroots

### DIFF
--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -504,33 +504,41 @@ def roots_cyclotomic(f, factor=False):
 
 def roots_quintic(f):
     """
-    Calculate exact roots of a solvable quintic
+    Calculate exact roots of a solvable irreducible quintic with rational coefficients. 
+    Return an empty list if the quintic is reducible or not solvable.
     """
     result = []
-    coeff_5, coeff_4, p, q, r, s = f.all_coeffs()
-
-    # Eqn must be of the form x^5 + px^3 + qx^2 + rx + s
-    if coeff_4:
-        return result
+    coeff_5, coeff_4, p_, q_, r_, s_ = f.all_coeffs()
 
     if coeff_5 != 1:
-        l = [p/coeff_5, q/coeff_5, r/coeff_5, s/coeff_5]
-        if not all(coeff.is_Rational for coeff in l):
-            return result
         f = Poly(f/coeff_5)
-    elif not all(coeff.is_Rational for coeff in (p, q, r, s)):
+        _, coeff_4, p_, q_, r_, s_ = f.all_coeffs()
+
+    # Cancel coeff_4 to form x^5 + px^3 + qx^2 + rx + s
+    if coeff_4:
+        p = p_ - 2*coeff_4*coeff_4/5
+        q = q_ - 3*coeff_4*p_/5 + 4*coeff_4**3/25
+        r = r_ - 2*coeff_4*q_/5 + 3*coeff_4**2*p_/25 - 3*coeff_4**4/125
+        s = s_ - coeff_4*r_/5 + coeff_4**2*q_/25 - coeff_4**3*p_/125 + 4*coeff_4**5/3125
+        x = f.gen
+        f = Poly(x**5 + p*x**3 + q*x**2 + r*x + s)
+    else:
+        p, q, r, s = p_, q_, r_, s_
+
+    if not all(coeff.is_Rational for coeff in (p, q, r, s)):
         return result
+        
     quintic = PolyQuintic(f)
 
     # Eqn standardized. Algo for solving starts here
     if not f.is_irreducible:
         return result
-
+        
     f20 = quintic.f20
     # Check if f20 has linear factors over domain Z
     if f20.is_irreducible:
         return result
-
+        
     # Now, we know that f is solvable
     for _factor in f20.factor_list()[1]:
         if _factor[0].is_linear:
@@ -635,7 +643,7 @@ def roots_quintic(f):
                 r2 = Res[2][i]
                 r3 = Res[3][j]
                 break
-        if r2:
+        if r2 is not None:
             break
     else:
         return []  # fall back to normal solve
@@ -658,6 +666,10 @@ def roots_quintic(f):
             # and fall back to usual solve
             return []
         saw.add(r)
+    
+    # Restore to original equation where coeff_4 is nonzero
+    if coeff_4:
+        result = [x - coeff_4 / 5 for x in result]
     return result
 
 


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Add support in `polys.polyroots.roots_quintic` to solve quintics with nonzero degree-4 coefficient by applying a linear transform. In the past, it only returned an empty list in this case.

Also fix a small bug in this function that it failed to solve quintics like 'x^5-2'. This was caused by miswriting `if r2 is not None` as `if r2`.

#### Other comments
Another tricky quintic that it fails to solve is presented below, which I guess is due to numerical instability. Maybe it should be fixed in the future.
```python3
sp.polys.polyroots.roots_quintic(sp.sympify('x^5-110*x^3-55*x^2+2310*x+979').subs('x','3*x').as_poly()) # fails
sp.polys.polyroots.roots_quintic(sp.sympify('x^5-110*x^3-55*x^2+2310*x+979').as_poly()) # good
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
